### PR TITLE
Fixed link to (renamed) astro-stylesheet page

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ __[Official Docs](https://docs.astro.build/getting-started)__ - __[What's Next?]
 
 ## Astro Packages/Libraries
 - [Astro SEO](https://github.com/jonasmerlin/astro-seo) - Better SEO with Astro
-- [Astro Stylesheet Component](https://www.npmjs.com/package/astro-ui-stylesheet) - Abstract the monotony of adding stylesheets to any Astro project
+- [Astro Stylesheet Component](https://www.npmjs.com/package/astro-stylesheet) - Abstract the monotony of adding stylesheets to any Astro project
 - [Astro Command](https://www.npmjs.com/package/astro-command) - Statically render commands and build components in any language
 - [Astro Pandoc](https://github.com/trashhalo/astro-pandoc) - Pandoc rendering for Astro
 - [Astro SPA](https://www.npmjs.com/package/astro-spa) - The SPA library for Astro that will turn your website into a Single Page Application


### PR DESCRIPTION
The link to "astro-ui-stylesheet" was broken, the component appears to have been renamed. Fixed link.