### PR TITLE
Add ParaglideJS to Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Pre 1.0
 - [Google Font Optimizer](https://github.com/sebholstein/astro-google-fonts-optimizer) - An Astro integration to optimize the Google Fonts loading performance
 - [Astro Firebase](https://github.com/thepassle/astro-firebase) - Deploy your server-side rendered (SSR) Astro app to Firebase
 - [Astro Font Picker](https://github.com/randombits-dev/astro-font-picker) - A Dev Toolbar Integration that lets you try out different fonts on your website
+- [ParaglideJS](https://inlang.com/m/iljlwzfs/library-inlang-paraglideJsAdapterAstro) - A tiny, type-safe i18n integration that only ships messages used on islands to the client.
 
 ## Built with Astro
 - https://astro.build/showcase/ (__Official Showcase Directory__)


### PR DESCRIPTION
This PR adds the [ParaglideJS](https://inlang.com/m/iljlwzfs/library-inlang-paraglideJsAdapterAstro) integration to the Integrations section. 
Paraglide is a tiny, type-safe i18n integration for Astro that only ships messages that are used on islands to the client. 