### PR TITLE
Add Tally to site list

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,4 +184,4 @@ Pre 1.0
 - [running.supply](https://running.supply/)
 - [sadman.ca](https://sadman.ca/) ([Source](https://github.com/sadmanca/blogv2))
 - [Matrix Digital Rain Online with Terminal](https://matrixscreensaver.online/)
-
+- [Tally](https://tally.johng.io) ([Source](https://github.com/twocaretcat/Tally))


### PR DESCRIPTION
Add [Tally](https://tally.johng.io) to 'Built With Astro' section.

## Description
<img width="1200" height="630" alt="og" src="https://github.com/user-attachments/assets/854a5ac1-924a-4609-b522-5505d8d9d1b4" />

**Tally - Word Counter** is a free online tool to count the number of characters, words, paragraphs, and lines in your text. It can also show counts for different types of characters like letters, digits, spaces, punctuation, and symbols/special characters. Make sure you have the right number of words for your essay or post by counting them instantly with **Tally**.

## Links
[Homepage](https://tally.johng.io) / [Source](https://github.com/twocaretcat/Tally)