### PR TITLE
Add Absurdity Index to Built with Astro

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,4 +191,5 @@ Pre 1.0
 - [Matrix Digital Rain Online with Terminal](https://matrixscreensaver.online/)
 - [Tally](https://tally.johng.io) ([Source](https://github.com/twocaretcat/Tally))
 - [Goldplated Photos](https://goldplated.photos) - Self-hosted photo gallery with file-based storage, password protection, and PhotoSwipe lightbox ([Source](https://github.com/klukacin/goldplated-photos))
+- [Absurdity Index](https://absurdityindex.org) - Satirical commentary site scoring real congressional legislation, built with Astro 5 + Tailwind CSS v4
 


### PR DESCRIPTION
## Add Absurdity Index to Built with Astro

**Site**: [absurdityindex.org](https://absurdityindex.org)

Absurdity Index is a satirical commentary site that scores real congressional legislation on an absurdity scale (1-10), with proof links to congress.gov for every claim.

### Tech Stack
- **Astro 5** with MDX content collections
- **Tailwind CSS v4** with custom government-parody theme
- Deployed on Cloudflare Pages

The entry has been added to the bottom of the "Built with Astro" section.