### PR TITLE
Add Lumina — academic website template

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Pre 1.0
 
 ## Built with Astro
 - https://astro.build/showcase/ (__Official Showcase Directory__)
+- [Lumina](https://github.com/YY-GX/Lumina) - Academic website template for researchers with BibTeX-native publications, 10 themes × 5 palettes, 18 toggleable pages, and one-file YAML configuration. Built with Astro 5 + Tailwind CSS 4.
 - [Designcember](https://designcember.com/#3rd)
 - [Serverless(CSS Tricks)](https://serverless.css-tricks.com/)
 - [Trivago - Tech Blog](https://tech.trivago.com/)


### PR DESCRIPTION
## What is Lumina?

  [Lumina](https://github.com/YY-GX/Lumina) is an academic website template designed for researchers, professors, and PhD students.

  **Key features:**
  - One YAML config file — no frontend experience needed
  - BibTeX-native publications page (drop your .bib, get venue badges + author highlighting)
  - 10 themes × 5 color palettes (50+ combinations), all with dark mode
  - 18 toggleable page types (Publications, CV, Blog, Projects, Teaching, News, Team, Gallery, etc.)
  - Astro 5 + Tailwind CSS 4, static output, GitHub Pages deploy workflow included

  **Live demo:** https://yy-gx.github.io

  Added under "Repositories/Starter Kits/Components".

  All you need to do is fork the repo, add the one line, and open the PR with the message above. Should take about 2 minutes on GitHub's web UI.