### PR TITLE
Add Debian Time Capsule – Retro browser desktop built with Astro

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,4 +191,4 @@ Pre 1.0
 - [Matrix Digital Rain Online with Terminal](https://matrixscreensaver.online/)
 - [Tally](https://tally.johng.io) ([Source](https://github.com/twocaretcat/Tally))
 - [Goldplated Photos](https://goldplated.photos) - Self-hosted photo gallery with file-based storage, password protection, and PhotoSwipe lightbox ([Source](https://github.com/klukacin/goldplated-photos))
-
+- [Debian Time Capsule](https://debian.com.mx) ([Source](https://github.com/victxrlarixs/debian-time-capsule))


### PR DESCRIPTION
Adds Debian Time Capsule, an experimental browser-based desktop environment built with Astro and TypeScript that recreates the experience of classic Linux desktops in the browser.