### PR TITLE
Add AIGC Portfolio to Starter Kits

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Pre 1.0
 - [Gurido](https://gurido.vercel.app/) A super cool, playfull and modern landing page template for agencies, studios or freelancers built with Astro and Tailwind CSS.
 - [MicroBlog](https://microblog-theta.vercel.app/) - An elegant blog website template built with Astro, Tailwind CSS and MDX.
 - [Quick Store](https://quickstorre.vercel.app/) - A minimal dark theme landing page to sell digital products.
+- [AIGC Portfolio](https://github.com/danielw-sudo/AIGC-portfolio) - AI-powered art gallery and blog template for Cloudflare Workers with multi-LLM support and zero-cost deployment.
 - [Astro Citrus](https://github.com/ArtemKutsan/astro-citrus) - A modern Astro blog theme with MDX and Tailwind CSS
 - [Starwind UI](https://github.com/starwind-ui/starwind-ui) - A set of powerful, accessible components for your Astro projects. Styled with Tailwind CSS v4.
 - [WebcoreUI](https://webcoreui.dev/) - Configurable and themeable Astro component UI library


### PR DESCRIPTION
Adds [AIGC Portfolio](https://github.com/danielw-sudo/AIGC-portfolio) to the Repositories/Starter Kits/Components section.

AI-powered art gallery and blog template for Cloudflare Workers with multi-LLM support (Cloudflare Workers AI, NVIDIA NIM, Google Gemini) and zero-cost deployment.

- Astro 5 SSR on Cloudflare Workers
- D1 database + R2 storage
- Admin dashboard with AI-assisted content analysis
- One-click deploy via setup script