### PR TITLE
Add PolyGlyph to Built with Astro

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,4 +191,5 @@ Pre 1.0
 - [Matrix Digital Rain Online with Terminal](https://matrixscreensaver.online/)
 - [Tally](https://tally.johng.io) ([Source](https://github.com/twocaretcat/Tally))
 - [Goldplated Photos](https://goldplated.photos) - Self-hosted photo gallery with file-based storage, password protection, and PhotoSwipe lightbox ([Source](https://github.com/klukacin/goldplated-photos))
+- [PolyGlyph](https://polyglyph.io/) - AI-powered SVG generation and editing tool built with Astro and Svelte 5
 


### PR DESCRIPTION
Adding [PolyGlyph](https://polyglyph.io/) to the "Built with Astro" section.

PolyGlyph is an AI-powered SVG generation and editing tool built with Astro 5 and Svelte 5. Type a prompt to generate a vector graphic, then edit it in a lightweight browser-based vector editor.

https://github.com/user-attachments/assets/3ee729da-00c9-4222-b194-998ecf81cc09