### PR TITLE
Add @aeorank/astro to Astro Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Pre 1.0
 - [Astro Snapshot](https://github.com/twocaretcat/astro-snapshot) - An Astro integration for generating screenshots of your pages automatically at build time
 - [ParaglideJS](https://inlang.com/m/iljlwzfs/library-inlang-paraglideJsAdapterAstro) - A tiny, type-safe i18n integration that only ships messages used on islands to the client.
 - [astro-cloudflare-pages-headers](https://github.com/martinsilha/astro-cloudflare-pages-headers) - A lightweight integration for Astro that automatically generates a Cloudflare Pages `_headers` file for deployments based on your server header configuration.
+- [@aeorank/astro](https://github.com/vinpatel/aeorank) - AEO (Answer Engine Optimization) integration for Astro — generates llms.txt, schema.json, and more AI-readable files
 
 ## Built with Astro
 - https://astro.build/showcase/ (__Official Showcase Directory__)


### PR DESCRIPTION
## Summary
- Adds [@aeorank/astro](https://www.npmjs.com/package/@aeorank/astro) to the **Astro Integrations** section
- AEO (Answer Engine Optimization) integration for Astro that generates `llms.txt`, `schema.json`, and more AI-readable files as an Astro integration
- [GitHub](https://github.com/vinpatel/aeorank) | [npm](https://www.npmjs.com/package/@aeorank/astro)