### PR TITLE
Add 讀角獸 (Ducorn) — Astro 4 + Cloudflare full-stack publication

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,4 +191,5 @@ Pre 1.0
 - [Matrix Digital Rain Online with Terminal](https://matrixscreensaver.online/)
 - [Tally](https://tally.johng.io) ([Source](https://github.com/twocaretcat/Tally))
 - [Goldplated Photos](https://goldplated.photos) - Self-hosted photo gallery with file-based storage, password protection, and PhotoSwipe lightbox ([Source](https://github.com/klukacin/goldplated-photos))
+- [讀角獸 (Ducorn)](https://ducorn.com) - Hybrid SSR/static publication built with Astro 4 + Cloudflare Pages/Workers/D1/KV/R2. Full Cloudflare stack: D1 for content, KV for sessions, R2 for media. 8 long-form Traditional Chinese deep-analysis articles.
 


### PR DESCRIPTION
Adding ducorn.com, a production publication built entirely on Astro 4 + Cloudflare:

- **Rendering:** Hybrid mode (static for articles + SSR for auth/API)
- **Database:** Cloudflare D1 (SQLite) for content, users, subscriptions
- **Sessions:** Cloudflare KV for magic link auth tokens
- **Media:** Cloudflare R2 for audio/images
- **Deployment:** Cloudflare Pages with Workers

It's a real-world example of Astro's hybrid rendering with the full Cloudflare ecosystem — zero external services except Resend for email.

- Website: https://ducorn.com
- 8 long-form articles, SSR API routes, magic link auth