### PR TITLE
Add Watchboard to Built with Astro

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,4 +191,5 @@ Pre 1.0
 - [Matrix Digital Rain Online with Terminal](https://matrixscreensaver.online/)
 - [Tally](https://tally.johng.io) ([Source](https://github.com/twocaretcat/Tally))
 - [Goldplated Photos](https://goldplated.photos) - Self-hosted photo gallery with file-based storage, password protection, and PhotoSwipe lightbox ([Source](https://github.com/klukacin/goldplated-photos))
+- [Watchboard](https://artemiop.com/watchboard/) - AI-powered intelligence dashboard platform with 48 trackers, CesiumJS 3D globe, Leaflet maps, and nightly automated data updates ([Source](https://github.com/ArtemioPadilla/watchboard))
 


### PR DESCRIPTION
Added [Watchboard](https://artemiop.com/watchboard/) to the "Built with Astro" section.

Watchboard is an AI-powered intelligence dashboard platform built with Astro 5 and React islands. It features:
- 48 topic trackers (conflicts, disasters, political events, space, science, culture)
- CesiumJS 3D globe with camera presets
- Leaflet interactive maps with category filters
- Satori-generated dynamic OG images per tracker
- Pagefind full-text search
- Nightly automated data updates via GitHub Actions
- Config-driven architecture: each tracker is a `tracker.json` + `data/` directory

Built with: Astro 5, React, CesiumJS, Leaflet, TypeScript, Zod

Live: https://artemiop.com/watchboard/
Source: https://github.com/ArtemioPadilla/watchboard