### PR TITLE
Add AstroDeck, Brook 2 and APEX templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Pre 1.0
 - [WebcoreUI](https://webcoreui.dev/) - Configurable and themeable Astro component UI library
 - - [AstroDeck](https://github.com/holger1411/astrodeck) - Production-ready Astro 6 starter with Tailwind CSS 4, shadcn/ui, dark mode, 11 page templates and 5 AI agents (AGENTS.md)
   - - [Brook 2](https://github.com/holger1411/astro-brook) - Minimalist Astro 6 blog template with Tailwind CSS 4, content collections, MDX, dark mode and clean typography
+- [APEX](https://templatedeck.com/templates/apex) - Premium multi-page B2B SaaS template with Astro 6, Tailwind CSS 4, shadcn/ui, dark mode, 16 page templates and AI-first AGENTS.md workflows
 
 ## Astro Packages/Libraries
 - [Astro SEO](https://github.com/jonasmerlin/astro-seo) - Better SEO with Astro
@@ -120,6 +121,7 @@ Pre 1.0
 - [Astro Command](https://www.npmjs.com/package/astro-command) - Statically render commands and build components in any language
 - [Astro Pandoc](https://github.com/trashhalo/astro-pandoc) - Pandoc rendering for Astro
 - [Astro SPA](https://www.npmjs.com/package/astro-spa) - The SPA library for Astro that will turn your website into a Single Page Application
+- 
 - [Astro Icon](https://github.com/natemoo-re/astro-icon) - Straight-forward Icon component for Astro
 - [Astro ImageTools](https://github.com/RafidMuhymin/astro-imagetools) - Image Optimization tools for the Astro JS framework
 - [Accessible Astro Components](https://www.npmjs.com/package/accessible-astro-components)

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ Pre 1.0
 - [Astro Citrus](https://github.com/ArtemKutsan/astro-citrus) - A modern Astro blog theme with MDX and Tailwind CSS
 - [Starwind UI](https://github.com/starwind-ui/starwind-ui) - A set of powerful, accessible components for your Astro projects. Styled with Tailwind CSS v4.
 - [WebcoreUI](https://webcoreui.dev/) - Configurable and themeable Astro component UI library
+- - [AstroDeck](https://github.com/holger1411/astrodeck) - Production-ready Astro 6 starter with Tailwind CSS 4, shadcn/ui, dark mode, 11 page templates and 5 AI agents (AGENTS.md)
+  - - [Brook 2](https://github.com/holger1411/astro-brook) - Minimalist Astro 6 blog template with Tailwind CSS 4, content collections, MDX, dark mode and clean typography
 
 ## Astro Packages/Libraries
 - [Astro SEO](https://github.com/jonasmerlin/astro-seo) - Better SEO with Astro


### PR DESCRIPTION
Adds three free, MIT-licensed Astro templates:

- **AstroDeck** — Open Source Full-featured Astro 6 + Tailwind CSS 4 starter with shadcn/ui components, dark mode, 11 page templates and AI agent support (AGENTS.md). Demo: https://www.astrodeck.dev/
- - **Brook 2** — Open Source Minimal Astro 6 blog template with content collections, MDX, dark mode and clean typography. Demo: https://brook2-astro-blog.vercel.app/
- - **APEX** — Premium multi-page B2B SaaS template with Astro 6, Tailwind CSS 4, shadcn/ui, dark mode, 16 page templates and AI-first AGENTS.md workflows. Demo: https://apex-template-three.vercel.app/
All are free and MIT-licensed. Part of the [TemplateDeck](https://templatedeck.com) collection.