### PR TITLE
Add Tailcast - Dark-themed website template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,12 @@
 # Awesome [Astro](https://twitter.com/astrodotbuild)
-
-Curated resources on **building sites with Astro**, a brand new way to build static and server rendered sites, with cross-framework components, styling and reactive store support. If you appreciate the content 📖, support projects visibility, give 👍| ⭐| 👏.
+Curated resources on __building sites with Astro__, a brand new way to build static and server rendered sites, with cross-framework components, styling and reactive store support. If you appreciate the content 📖, support projects visibility, give 👍| ⭐| 👏.
 
 Astro is _super duper new_, improving, and becoming more expressive + powerful, but few of the APIs are still evolving. This page aspires to collect all the valauble references out there, and be a useful go-to resource when astro hits it's first stable version.
 
-**[Official Docs](https://docs.astro.build)** | [Launch a new project](https://astro.new/) , or use [Code Sandbox](https://codesandbox.io/p/github/codesandbox/codesandbox-template-astro/main?file=%2FREADME.md)
+__[Official Docs](https://docs.astro.build)__ | [Launch a new project](https://astro.new/) , or use [Code Sandbox](https://codesandbox.io/p/github/codesandbox/codesandbox-template-astro/main?file=%2FREADME.md)
 
 ## ✍️ Blogs
-
-Look for **NEW** against the post titles to find the blogs published after Astro 1.0
-
+Look for __NEW__ against the post titles to find the blogs published after Astro 1.0
 - [Introducing Astro: Ship Less JavaScript](https://astro.build/blog/introducing-astro) - [Fred K. Schott](https://twitter.com/FredKSchott)
 - [A Look at Building with Astro](https://css-tricks.com/a-look-at-building-with-astro/) - [Chris Coyier](https://twitter.com/chriscoyier)
 - [Thoughts on Astro](https://css-tricks.com/newsletter/255-thoughts-on-astro/) - [Chris Coyier](https://twitter.com/chriscoyier)
@@ -24,30 +21,30 @@ Look for **NEW** against the post titles to find the blogs published after Astro
 - [Astro Will Become Your Favorite Static Site Generator](https://javascript.plainenglish.io/astro-906b03f63ab8)
 - [Build a Recipe collection website with Astro](https://daily-dev-tips.com/posts/astro-recipe-collection-website-part-1-setup-collections) - Parts &rarr; [1](https://daily-dev-tips.com/posts/astro-recipe-collection-website-part-1-setup-collections/) - [2](https://daily-dev-tips.com/posts/astro-recipe-collection-website-part-2-homepage-rendering/) - [3](https://daily-dev-tips.com/posts/astro-recipe-collection-website-part-3-category-filter-pages/) - [4](https://daily-dev-tips.com/posts/astro-recipe-collection-website-part-4-styling-the-website/) - [5](https://daily-dev-tips.com/posts/astro-recipe-collection-website-part-5-hosting-on-netlify/)
 - [Astro: Build faster apps with less JavaScript](https://blog.logrocket.com/astro-build-faster-apps-less-javascript/)
-- [Series - Learn Astro while building Ink - Get Up & Running](https://aalam.in/blog/astro-get-up-and-running)
-- [Series - Learn Astro while building Ink - Astro and Site Structure](https://aalam.in/blog/astro-and-site-strcuture)
-- [Series - Learn Astro while building Ink - Astro and Data](https://aalam.in/blog/astro-and-data)
-- [Series - Learn Astro while building Ink - Astro and Interactivity](https://aalam.in/blog/astro-and-interactivity)
+- [Series - Learn Astro while building Ink - Get Up & Running](https://aalam.in/blog/astro-get-up-and-running) 
+- [Series - Learn Astro while building Ink - Astro and Site Structure](https://aalam.in/blog/astro-and-site-strcuture) 
+- [Series - Learn Astro while building Ink - Astro and Data](https://aalam.in/blog/astro-and-data) 
+- [Series - Learn Astro while building Ink - Astro and Interactivity](https://aalam.in/blog/astro-and-interactivity) 
 - [Series - Learn Astro while building Ink - Astro and Dynamic Pages](https://aalam.in/blog/astro-and-dynamic-pages)
 - [Getting started with Astro](https://rodneylab.com/getting-started-astro/)
 - [Migrating from SvelteKit to Astro](https://byteofdev.com/posts/sveltekit-to-astro/)
 - [Personal website with Astro, Tailwind CSS, and Nx](https://leosvel.dev/blog/creating-my-personal-website-with-astro-tailwindcss-and-nx/)
 - [Astro on Cloudflare Workers](https://dev.to/thepassle/astro-on-cloudflare-workers-2ng7)
 - [The case about Astro](https://okupter.com/blog/the-case-about-astro/)
-- [Explore the Benefits of Astro.js by Building a Quick App](https://prismic.io/blog/astro-js-tutorial) **NEW**
-- [Experiments with Astro and the Shared Element Transition API](https://www.maxiferreira.com/blog/astro-page-transitions/) **NEW**
-- [Building serverless applications with Fauna + GraphQL + Astro](https://bholmes.dev/blog/serverless-apps-fauna-gql-astro/) **NEW**
-- [Learn how to install Astro with Tailwind CSS and Flowbite](https://flowbite.com/docs/getting-started/astro/) **NEW**
-- [Automatic article suggestions in Astro](https://www.nmattia.com/posts/2023-02-25-astro-suggestions/) **NEW**
-- [Learn Astro by creating your web portfolio (Spanish)](https://www.webreactiva.com/bootcamp/astro) **NEW**
-- [Animated SVGs - The Ultimate Web Format](https://aminoffz.github.io/blog/blog/animated-svgs/) **NEW**
-- [An introduction to Astro's content system](https://kristianfreeman.com/an-introduction-to-astros-content-system/) **NEW**
-- [How to Implement RBAC (Role-Based Access Control) in Astro Framework](https://www.permit.io/blog/how-to-implement-rbac-role-based-access-control-in-astro-framework) **NEW**
-- [How to use Goodreads data in Astro](https://sadman.ca/posts/how-to-use-goodreads-data-in-astro/) **NEW**
+- [Explore the Benefits of Astro.js by Building a Quick App](https://prismic.io/blog/astro-js-tutorial) __NEW__
+- [Experiments with Astro and the Shared Element Transition API](https://www.maxiferreira.com/blog/astro-page-transitions/) __NEW__
+- [Building serverless applications with Fauna + GraphQL + Astro](https://bholmes.dev/blog/serverless-apps-fauna-gql-astro/) __NEW__
+- [Learn how to install Astro with Tailwind CSS and Flowbite](https://flowbite.com/docs/getting-started/astro/) __NEW__
+- [Automatic article suggestions in Astro](https://www.nmattia.com/posts/2023-02-25-astro-suggestions/) __NEW__
+- [Learn Astro by creating your web portfolio (Spanish)](https://www.webreactiva.com/bootcamp/astro) __NEW__
+- [Animated SVGs - The Ultimate Web Format](https://aminoffz.github.io/blog/blog/animated-svgs/) __NEW__
+- [An introduction to Astro's content system](https://kristianfreeman.com/an-introduction-to-astros-content-system/) __NEW__
+- [How to Implement RBAC (Role-Based Access Control) in Astro Framework](https://www.permit.io/blog/how-to-implement-rbac-role-based-access-control-in-astro-framework) __NEW__
+- [How to use Goodreads data in Astro](https://sadman.ca/posts/how-to-use-goodreads-data-in-astro/) __NEW__
 - [Set up FlyonUI with Astro using Tailwind CSS](https://flyonui.com/docs/framework-integrations/astro/)
 
-## 📹 Videos/Screencasts/Twitch
 
+## 📹 Videos/Screencasts/Twitch
 - [Astro just Launched.... Could it be the ultimate web framework?](https://www.youtube.com/watch?v=gxBkghlglTg)
 - [Brad Traversy's Astro Crash Course](https://www.youtube.com/watch?v=Oi9z5gfIHJs)
 - [What’s New in Astro v1?](https://www.learnwithjason.dev/what-s-new-in-astro-v1)
@@ -58,31 +55,29 @@ Look for **NEW** against the post titles to find the blogs published after Astro
 - [Taking Astro for a ride - portfolio edition](https://www.youtube.com/watch?v=QkY_rZpjEew)
 
 Pre 1.0
-
-- [Ship Less JavaScript with Astro](https://www.learnwithjason.dev/ship-less-javascript-with-astro) - **Fredd K. Schott** & **Jason Lengstorf**
-- [Speakeasy JS – Astro: A New Architecture for the Modern Web](https://www.youtube.com/watch?v=mgkwZqVkrwo) - **Fred K. Schott** (YouTube - Speakeasy JS)
-- [Astro in 100 Seconds](https://www.youtube.com/watch?v=dsTXcSeAZq8) - **Jeff Delaney** (Fireship)
-- [Yapping About Astro](https://www.youtube.com/watch?v=3jPaidbpUIA) - **Chris Coyier** (CSS Tricks)
-- [Astro FTW! Vue and React can work together in the same app](https://www.youtube.com/watch?v=sUrxtZA2sA0) - **Jamstack Fridays**
-- [Learning Astro with Nate Moore](https://www.youtube.com/watch?v=def9EgQzRUw) - **Nate Moore** (YouTube - React Wednesdays)
-- [Ship less JS with Astro](https://courses.jamstack.training/p/ship-less-javascript-with-astro) - **Jamstack Training**
-- [Create template layouts for your HTML with Astro SSG](https://www.youtube.com/watch?v=o7iQAF2EvUU) - **Kevin Powell**
+- [Ship Less JavaScript with Astro](https://www.learnwithjason.dev/ship-less-javascript-with-astro) - __Fredd K. Schott__ & __Jason Lengstorf__
+- [Speakeasy JS – Astro: A New Architecture for the Modern Web](https://www.youtube.com/watch?v=mgkwZqVkrwo) - __Fred K. Schott__ (YouTube - Speakeasy JS)
+- [Astro in 100 Seconds](https://www.youtube.com/watch?v=dsTXcSeAZq8) - __Jeff Delaney__ (Fireship)
+- [Yapping About Astro](https://www.youtube.com/watch?v=3jPaidbpUIA) - __Chris Coyier__ (CSS Tricks)
+- [Astro FTW! Vue and React can work together in the same app](https://www.youtube.com/watch?v=sUrxtZA2sA0) - __Jamstack Fridays__
+- [Learning Astro with Nate Moore](https://www.youtube.com/watch?v=def9EgQzRUw) - __Nate Moore__ (YouTube - React Wednesdays)
+- [Ship less JS with Astro](https://courses.jamstack.training/p/ship-less-javascript-with-astro) - __Jamstack Training__
+- [Create template layouts for your HTML with Astro SSG](https://www.youtube.com/watch?v=o7iQAF2EvUU) - __Kevin Powell__
 - [Build faster websites with Astro](https://www.youtube.com/watch?v=x3hiyWikdrE)
 - [Add comments with Airtable and Netlify](https://www.youtube.com/watch?v=IEpP05XSwWE)
 - [Grow Community Through Open Source | Fred K. Schott of Astro| The Secret Sauce](https://www.youtube.com/watch?v=IjujjSU_cOA)
 
 ## 🧶 Condensed Thought-pieces (Twitter Threads)
-
-- [**Georges** on Astro](https://twitter.com/georges_gomes/status/1380801812656226304) as a meta web framework
-- [**Nate Moore** on Incremental Framework adoption](https://twitter.com/astrodotbuild/status/1414283562795208707), [Solid.js](https://www.solidjs.com/) support, and a future without `import React from 'react'` for components.
-- [**Matthew Phillips** on Astro for Web Components](https://twitter.com/matthewcp/status/1411050609105637377), [lit](https://twitter.com/matthewcp/status/1407826230129332228) and server-rendered custom elements
-- [**Matthew Phillips** on Astro Loading](https://twitter.com/matthewcp/status/1414957982652243970)
-- [**Nate Moore** on baseline JS bundle size](https://twitter.com/n_moore/status/1415067187446960129)
+- [__Georges__ on Astro](https://twitter.com/georges_gomes/status/1380801812656226304) as a meta web framework
+- [__Nate Moore__ on Incremental Framework adoption](https://twitter.com/astrodotbuild/status/1414283562795208707), [Solid.js](https://www.solidjs.com/) support, and a future without `import React from 'react'` for components.
+- [__Matthew Phillips__ on Astro for Web Components](https://twitter.com/matthewcp/status/1411050609105637377), [lit](https://twitter.com/matthewcp/status/1407826230129332228) and server-rendered custom elements
+- [__Matthew Phillips__ on Astro Loading](https://twitter.com/matthewcp/status/1414957982652243970)
+- [__Nate Moore__ on baseline JS bundle size](https://twitter.com/n_moore/status/1415067187446960129)
 - [Build a landing page in 30 seconds](https://twitter.com/astrodotbuild/status/1565438744500502528)
 - [Client-side routing experience with Shared Element Transitions API](https://twitter.com/charca/status/1562933467104440321)
 
-## ℹ️ Repositories/Starter Kits/Components
 
+## ℹ️ Repositories/Starter Kits/Components
 - [Astro-react-vue-demo](https://github.com/cassidoo/astro-react-vue-demo)
 - [Astro-netlify-starter](https://github.com/cassidoo/astro-netlify-starter)
 - [Astro Ink](https://github.com/one-aalam/astro-ink) - Crisp, minimal, personal blog theme for Astro
@@ -117,9 +112,8 @@ Pre 1.0
 - [Starwind UI](https://github.com/starwind-ui/starwind-ui) - A set of powerful, accessible components for your Astro projects. Styled with Tailwind CSS v4.
 - [WebcoreUI](https://webcoreui.dev/) - Configurable and themeable Astro component UI library
 - [Tailcast](https://github.com/matt765/Tailcast) - Dark-themed website template built with Astro and Tailwind CSS. 8 pages, SEO optimization, and view transitions.
-
+  
 ## Astro Packages/Libraries
-
 - [Astro SEO](https://github.com/jonasmerlin/astro-seo) - Better SEO with Astro
 - [Astro Stylesheet Component](https://www.npmjs.com/package/astro-stylesheet) - Abstract the monotony of adding stylesheets to any Astro project
 - [Astro Command](https://www.npmjs.com/package/astro-command) - Statically render commands and build components in any language
@@ -144,7 +138,6 @@ Pre 1.0
 - [astro-loader-goodreads](https://github.com/sadmanca/astro-loader-goodreads) - Load Goodreads data for books in shelves/lists, user updates, and author blogs into Astro.
 
 ## Astro Integrations
-
 - [Astro Content](https://github.com/JulianCataldo/astro-content) - A text based, structured content manager, for edition and consumption — AstroJS Integration
 - [@storyblok/astro](https://github.com/storyblok/storyblok-astro) - Astro module for the Storyblok, Headless CMS
 - [@unocss/astro](https://github.com/unocss/unocss/tree/main/packages/astro) - The UnoCSS integration for Astro
@@ -157,8 +150,7 @@ Pre 1.0
 - [astro-cloudflare-pages-headers](https://github.com/martinsilha/astro-cloudflare-pages-headers) - A lightweight integration for Astro that automatically generates a Cloudflare Pages `_headers` file for deployments based on your server header configuration.
 
 ## Built with Astro
-
-- https://astro.build/showcase/ (**Official Showcase Directory**)
+- https://astro.build/showcase/ (__Official Showcase Directory__)
 - [Designcember](https://designcember.com/#3rd)
 - [Serverless(CSS Tricks)](https://serverless.css-tricks.com/)
 - [Trivago - Tech Blog](https://tech.trivago.com/)
@@ -200,3 +192,4 @@ Pre 1.0
 - [Matrix Digital Rain Online with Terminal](https://matrixscreensaver.online/)
 - [Tally](https://tally.johng.io) ([Source](https://github.com/twocaretcat/Tally))
 - [Goldplated Photos](https://goldplated.photos) - Self-hosted photo gallery with file-based storage, password protection, and PhotoSwipe lightbox ([Source](https://github.com/klukacin/goldplated-photos))
+

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # Awesome [Astro](https://twitter.com/astrodotbuild)
-Curated resources on __building sites with Astro__, a brand new way to build static and server rendered sites, with cross-framework components, styling and reactive store support. If you appreciate the content 📖, support projects visibility, give 👍| ⭐| 👏.
+
+Curated resources on **building sites with Astro**, a brand new way to build static and server rendered sites, with cross-framework components, styling and reactive store support. If you appreciate the content 📖, support projects visibility, give 👍| ⭐| 👏.
 
 Astro is _super duper new_, improving, and becoming more expressive + powerful, but few of the APIs are still evolving. This page aspires to collect all the valauble references out there, and be a useful go-to resource when astro hits it's first stable version.
 
-__[Official Docs](https://docs.astro.build)__ | [Launch a new project](https://astro.new/) , or use [Code Sandbox](https://codesandbox.io/p/github/codesandbox/codesandbox-template-astro/main?file=%2FREADME.md)
+**[Official Docs](https://docs.astro.build)** | [Launch a new project](https://astro.new/) , or use [Code Sandbox](https://codesandbox.io/p/github/codesandbox/codesandbox-template-astro/main?file=%2FREADME.md)
 
 ## ✍️ Blogs
-Look for __NEW__ against the post titles to find the blogs published after Astro 1.0
+
+Look for **NEW** against the post titles to find the blogs published after Astro 1.0
+
 - [Introducing Astro: Ship Less JavaScript](https://astro.build/blog/introducing-astro) - [Fred K. Schott](https://twitter.com/FredKSchott)
 - [A Look at Building with Astro](https://css-tricks.com/a-look-at-building-with-astro/) - [Chris Coyier](https://twitter.com/chriscoyier)
 - [Thoughts on Astro](https://css-tricks.com/newsletter/255-thoughts-on-astro/) - [Chris Coyier](https://twitter.com/chriscoyier)
@@ -21,30 +24,30 @@ Look for __NEW__ against the post titles to find the blogs published after Astro
 - [Astro Will Become Your Favorite Static Site Generator](https://javascript.plainenglish.io/astro-906b03f63ab8)
 - [Build a Recipe collection website with Astro](https://daily-dev-tips.com/posts/astro-recipe-collection-website-part-1-setup-collections) - Parts &rarr; [1](https://daily-dev-tips.com/posts/astro-recipe-collection-website-part-1-setup-collections/) - [2](https://daily-dev-tips.com/posts/astro-recipe-collection-website-part-2-homepage-rendering/) - [3](https://daily-dev-tips.com/posts/astro-recipe-collection-website-part-3-category-filter-pages/) - [4](https://daily-dev-tips.com/posts/astro-recipe-collection-website-part-4-styling-the-website/) - [5](https://daily-dev-tips.com/posts/astro-recipe-collection-website-part-5-hosting-on-netlify/)
 - [Astro: Build faster apps with less JavaScript](https://blog.logrocket.com/astro-build-faster-apps-less-javascript/)
-- [Series - Learn Astro while building Ink - Get Up & Running](https://aalam.in/blog/astro-get-up-and-running) 
-- [Series - Learn Astro while building Ink - Astro and Site Structure](https://aalam.in/blog/astro-and-site-strcuture) 
-- [Series - Learn Astro while building Ink - Astro and Data](https://aalam.in/blog/astro-and-data) 
-- [Series - Learn Astro while building Ink - Astro and Interactivity](https://aalam.in/blog/astro-and-interactivity) 
+- [Series - Learn Astro while building Ink - Get Up & Running](https://aalam.in/blog/astro-get-up-and-running)
+- [Series - Learn Astro while building Ink - Astro and Site Structure](https://aalam.in/blog/astro-and-site-strcuture)
+- [Series - Learn Astro while building Ink - Astro and Data](https://aalam.in/blog/astro-and-data)
+- [Series - Learn Astro while building Ink - Astro and Interactivity](https://aalam.in/blog/astro-and-interactivity)
 - [Series - Learn Astro while building Ink - Astro and Dynamic Pages](https://aalam.in/blog/astro-and-dynamic-pages)
 - [Getting started with Astro](https://rodneylab.com/getting-started-astro/)
 - [Migrating from SvelteKit to Astro](https://byteofdev.com/posts/sveltekit-to-astro/)
 - [Personal website with Astro, Tailwind CSS, and Nx](https://leosvel.dev/blog/creating-my-personal-website-with-astro-tailwindcss-and-nx/)
 - [Astro on Cloudflare Workers](https://dev.to/thepassle/astro-on-cloudflare-workers-2ng7)
 - [The case about Astro](https://okupter.com/blog/the-case-about-astro/)
-- [Explore the Benefits of Astro.js by Building a Quick App](https://prismic.io/blog/astro-js-tutorial) __NEW__
-- [Experiments with Astro and the Shared Element Transition API](https://www.maxiferreira.com/blog/astro-page-transitions/) __NEW__
-- [Building serverless applications with Fauna + GraphQL + Astro](https://bholmes.dev/blog/serverless-apps-fauna-gql-astro/) __NEW__
-- [Learn how to install Astro with Tailwind CSS and Flowbite](https://flowbite.com/docs/getting-started/astro/) __NEW__
-- [Automatic article suggestions in Astro](https://www.nmattia.com/posts/2023-02-25-astro-suggestions/) __NEW__
-- [Learn Astro by creating your web portfolio (Spanish)](https://www.webreactiva.com/bootcamp/astro) __NEW__
-- [Animated SVGs - The Ultimate Web Format](https://aminoffz.github.io/blog/blog/animated-svgs/) __NEW__
-- [An introduction to Astro's content system](https://kristianfreeman.com/an-introduction-to-astros-content-system/) __NEW__
-- [How to Implement RBAC (Role-Based Access Control) in Astro Framework](https://www.permit.io/blog/how-to-implement-rbac-role-based-access-control-in-astro-framework) __NEW__
-- [How to use Goodreads data in Astro](https://sadman.ca/posts/how-to-use-goodreads-data-in-astro/) __NEW__
+- [Explore the Benefits of Astro.js by Building a Quick App](https://prismic.io/blog/astro-js-tutorial) **NEW**
+- [Experiments with Astro and the Shared Element Transition API](https://www.maxiferreira.com/blog/astro-page-transitions/) **NEW**
+- [Building serverless applications with Fauna + GraphQL + Astro](https://bholmes.dev/blog/serverless-apps-fauna-gql-astro/) **NEW**
+- [Learn how to install Astro with Tailwind CSS and Flowbite](https://flowbite.com/docs/getting-started/astro/) **NEW**
+- [Automatic article suggestions in Astro](https://www.nmattia.com/posts/2023-02-25-astro-suggestions/) **NEW**
+- [Learn Astro by creating your web portfolio (Spanish)](https://www.webreactiva.com/bootcamp/astro) **NEW**
+- [Animated SVGs - The Ultimate Web Format](https://aminoffz.github.io/blog/blog/animated-svgs/) **NEW**
+- [An introduction to Astro's content system](https://kristianfreeman.com/an-introduction-to-astros-content-system/) **NEW**
+- [How to Implement RBAC (Role-Based Access Control) in Astro Framework](https://www.permit.io/blog/how-to-implement-rbac-role-based-access-control-in-astro-framework) **NEW**
+- [How to use Goodreads data in Astro](https://sadman.ca/posts/how-to-use-goodreads-data-in-astro/) **NEW**
 - [Set up FlyonUI with Astro using Tailwind CSS](https://flyonui.com/docs/framework-integrations/astro/)
 
-
 ## 📹 Videos/Screencasts/Twitch
+
 - [Astro just Launched.... Could it be the ultimate web framework?](https://www.youtube.com/watch?v=gxBkghlglTg)
 - [Brad Traversy's Astro Crash Course](https://www.youtube.com/watch?v=Oi9z5gfIHJs)
 - [What’s New in Astro v1?](https://www.learnwithjason.dev/what-s-new-in-astro-v1)
@@ -55,29 +58,31 @@ Look for __NEW__ against the post titles to find the blogs published after Astro
 - [Taking Astro for a ride - portfolio edition](https://www.youtube.com/watch?v=QkY_rZpjEew)
 
 Pre 1.0
-- [Ship Less JavaScript with Astro](https://www.learnwithjason.dev/ship-less-javascript-with-astro) - __Fredd K. Schott__ & __Jason Lengstorf__
-- [Speakeasy JS – Astro: A New Architecture for the Modern Web](https://www.youtube.com/watch?v=mgkwZqVkrwo) - __Fred K. Schott__ (YouTube - Speakeasy JS)
-- [Astro in 100 Seconds](https://www.youtube.com/watch?v=dsTXcSeAZq8) - __Jeff Delaney__ (Fireship)
-- [Yapping About Astro](https://www.youtube.com/watch?v=3jPaidbpUIA) - __Chris Coyier__ (CSS Tricks)
-- [Astro FTW! Vue and React can work together in the same app](https://www.youtube.com/watch?v=sUrxtZA2sA0) - __Jamstack Fridays__
-- [Learning Astro with Nate Moore](https://www.youtube.com/watch?v=def9EgQzRUw) - __Nate Moore__ (YouTube - React Wednesdays)
-- [Ship less JS with Astro](https://courses.jamstack.training/p/ship-less-javascript-with-astro) - __Jamstack Training__
-- [Create template layouts for your HTML with Astro SSG](https://www.youtube.com/watch?v=o7iQAF2EvUU) - __Kevin Powell__
+
+- [Ship Less JavaScript with Astro](https://www.learnwithjason.dev/ship-less-javascript-with-astro) - **Fredd K. Schott** & **Jason Lengstorf**
+- [Speakeasy JS – Astro: A New Architecture for the Modern Web](https://www.youtube.com/watch?v=mgkwZqVkrwo) - **Fred K. Schott** (YouTube - Speakeasy JS)
+- [Astro in 100 Seconds](https://www.youtube.com/watch?v=dsTXcSeAZq8) - **Jeff Delaney** (Fireship)
+- [Yapping About Astro](https://www.youtube.com/watch?v=3jPaidbpUIA) - **Chris Coyier** (CSS Tricks)
+- [Astro FTW! Vue and React can work together in the same app](https://www.youtube.com/watch?v=sUrxtZA2sA0) - **Jamstack Fridays**
+- [Learning Astro with Nate Moore](https://www.youtube.com/watch?v=def9EgQzRUw) - **Nate Moore** (YouTube - React Wednesdays)
+- [Ship less JS with Astro](https://courses.jamstack.training/p/ship-less-javascript-with-astro) - **Jamstack Training**
+- [Create template layouts for your HTML with Astro SSG](https://www.youtube.com/watch?v=o7iQAF2EvUU) - **Kevin Powell**
 - [Build faster websites with Astro](https://www.youtube.com/watch?v=x3hiyWikdrE)
 - [Add comments with Airtable and Netlify](https://www.youtube.com/watch?v=IEpP05XSwWE)
 - [Grow Community Through Open Source | Fred K. Schott of Astro| The Secret Sauce](https://www.youtube.com/watch?v=IjujjSU_cOA)
 
 ## 🧶 Condensed Thought-pieces (Twitter Threads)
-- [__Georges__ on Astro](https://twitter.com/georges_gomes/status/1380801812656226304) as a meta web framework
-- [__Nate Moore__ on Incremental Framework adoption](https://twitter.com/astrodotbuild/status/1414283562795208707), [Solid.js](https://www.solidjs.com/) support, and a future without `import React from 'react'` for components.
-- [__Matthew Phillips__ on Astro for Web Components](https://twitter.com/matthewcp/status/1411050609105637377), [lit](https://twitter.com/matthewcp/status/1407826230129332228) and server-rendered custom elements
-- [__Matthew Phillips__ on Astro Loading](https://twitter.com/matthewcp/status/1414957982652243970)
-- [__Nate Moore__ on baseline JS bundle size](https://twitter.com/n_moore/status/1415067187446960129)
+
+- [**Georges** on Astro](https://twitter.com/georges_gomes/status/1380801812656226304) as a meta web framework
+- [**Nate Moore** on Incremental Framework adoption](https://twitter.com/astrodotbuild/status/1414283562795208707), [Solid.js](https://www.solidjs.com/) support, and a future without `import React from 'react'` for components.
+- [**Matthew Phillips** on Astro for Web Components](https://twitter.com/matthewcp/status/1411050609105637377), [lit](https://twitter.com/matthewcp/status/1407826230129332228) and server-rendered custom elements
+- [**Matthew Phillips** on Astro Loading](https://twitter.com/matthewcp/status/1414957982652243970)
+- [**Nate Moore** on baseline JS bundle size](https://twitter.com/n_moore/status/1415067187446960129)
 - [Build a landing page in 30 seconds](https://twitter.com/astrodotbuild/status/1565438744500502528)
 - [Client-side routing experience with Shared Element Transitions API](https://twitter.com/charca/status/1562933467104440321)
 
-
 ## ℹ️ Repositories/Starter Kits/Components
+
 - [Astro-react-vue-demo](https://github.com/cassidoo/astro-react-vue-demo)
 - [Astro-netlify-starter](https://github.com/cassidoo/astro-netlify-starter)
 - [Astro Ink](https://github.com/one-aalam/astro-ink) - Crisp, minimal, personal blog theme for Astro
@@ -111,8 +116,10 @@ Pre 1.0
 - [Astro Citrus](https://github.com/ArtemKutsan/astro-citrus) - A modern Astro blog theme with MDX and Tailwind CSS
 - [Starwind UI](https://github.com/starwind-ui/starwind-ui) - A set of powerful, accessible components for your Astro projects. Styled with Tailwind CSS v4.
 - [WebcoreUI](https://webcoreui.dev/) - Configurable and themeable Astro component UI library
+- [Tailcast](https://github.com/matt765/Tailcast) - Dark-themed website template built with Astro and Tailwind CSS. 8 pages, SEO optimization, and view transitions.
 
 ## Astro Packages/Libraries
+
 - [Astro SEO](https://github.com/jonasmerlin/astro-seo) - Better SEO with Astro
 - [Astro Stylesheet Component](https://www.npmjs.com/package/astro-stylesheet) - Abstract the monotony of adding stylesheets to any Astro project
 - [Astro Command](https://www.npmjs.com/package/astro-command) - Statically render commands and build components in any language
@@ -137,6 +144,7 @@ Pre 1.0
 - [astro-loader-goodreads](https://github.com/sadmanca/astro-loader-goodreads) - Load Goodreads data for books in shelves/lists, user updates, and author blogs into Astro.
 
 ## Astro Integrations
+
 - [Astro Content](https://github.com/JulianCataldo/astro-content) - A text based, structured content manager, for edition and consumption — AstroJS Integration
 - [@storyblok/astro](https://github.com/storyblok/storyblok-astro) - Astro module for the Storyblok, Headless CMS
 - [@unocss/astro](https://github.com/unocss/unocss/tree/main/packages/astro) - The UnoCSS integration for Astro
@@ -149,7 +157,8 @@ Pre 1.0
 - [astro-cloudflare-pages-headers](https://github.com/martinsilha/astro-cloudflare-pages-headers) - A lightweight integration for Astro that automatically generates a Cloudflare Pages `_headers` file for deployments based on your server header configuration.
 
 ## Built with Astro
-- https://astro.build/showcase/ (__Official Showcase Directory__)
+
+- https://astro.build/showcase/ (**Official Showcase Directory**)
 - [Designcember](https://designcember.com/#3rd)
 - [Serverless(CSS Tricks)](https://serverless.css-tricks.com/)
 - [Trivago - Tech Blog](https://tech.trivago.com/)
@@ -191,4 +200,3 @@ Pre 1.0
 - [Matrix Digital Rain Online with Terminal](https://matrixscreensaver.online/)
 - [Tally](https://tally.johng.io) ([Source](https://github.com/twocaretcat/Tally))
 - [Goldplated Photos](https://goldplated.photos) - Self-hosted photo gallery with file-based storage, password protection, and PhotoSwipe lightbox ([Source](https://github.com/klukacin/goldplated-photos))
-


### PR DESCRIPTION
Adding [Tailcast](https://github.com/matt765/Tailcast) to the Repositories/Starter Kits section.

Dark-themed website template built with Astro and Tailwind CSS. 8 pages, SEO optimization, and view transitions.

- Live demo: https://tailcast.vercel.app
- MIT licensed
