### PR TITLE
Add MarkdownMaster — Markdown editor built with Astro

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,5 +190,5 @@ Pre 1.0
 - [sadman.ca](https://sadman.ca/) ([Source](https://github.com/sadmanca/blogv2))
 - [Matrix Digital Rain Online with Terminal](https://matrixscreensaver.online/)
 - [Tally](https://tally.johng.io) ([Source](https://github.com/twocaretcat/Tally))
-- [Goldplated Photos](https://goldplated.photos) - Self-hosted photo gallery with file-based storage, password protection, and PhotoSwipe lightbox ([Source](https://github.com/klukacin/goldplated-photos))
+- [MarkdownMaster](https://markdownmaster.site/) - Free online Markdown editor — real-time preview, GFM support, syntax highlighting for 100+ languages. Client-side, no sign-up. ([Source](https://github.com/tzhkai/markdownmaster))
 


### PR DESCRIPTION
MarkdownMaster is a free online Markdown editor with real-time preview, GFM support, and syntax highlighting — built entirely with Astro (static generation) on Cloudflare Pages.

**Website**: https://markdownmaster.site
**Source**: https://github.com/tzhkai/markdownmaster