### PR TITLE
Add @dualmark/astro to Astro Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Pre 1.0
 - [Astro Snapshot](https://github.com/twocaretcat/astro-snapshot) - An Astro integration for generating screenshots of your pages automatically at build time
 - [ParaglideJS](https://inlang.com/m/iljlwzfs/library-inlang-paraglideJsAdapterAstro) - A tiny, type-safe i18n integration that only ships messages used on islands to the client.
 - [astro-cloudflare-pages-headers](https://github.com/martinsilha/astro-cloudflare-pages-headers) - A lightweight integration for Astro that automatically generates a Cloudflare Pages `_headers` file for deployments based on your server header configuration.
+- [@dualmark/astro](https://github.com/dodopayments/dualmark/tree/main/packages/astro) - Open-source AEO (Answer Engine Optimization) integration. Auto-generates `.md` endpoints from your collections, ships a `Link rel=alternate` middleware, and generates `/llms.txt` — so AI search engines can read your Astro site cleanly. Includes a conformance CLI (`dualmark verify <url>`).
 
 ## Built with Astro
 - https://astro.build/showcase/ (__Official Showcase Directory__)


### PR DESCRIPTION
Adds [@dualmark/astro](https://www.npmjs.com/package/@dualmark/astro) to the **Astro Integrations** section.

Drop-in Astro 5 integration that auto-generates `.md` endpoints for every content collection (and an `llms.txt`), so ChatGPT, Claude, Perplexity, and Gemini get clean markdown when crawling your site — while humans still get the polished HTML. Picked by HTTP content negotiation; no duplicate-content risk.

- 35 tests, 80/80 on the bundled `astro-blog` example, 125/125 on the `astro-cloudflare-full` example
- Apache 2.0, npm provenance attested (Sigstore-signed)
- 30-second install: `bun add @dualmark/astro` + 5-line `astro.config.mjs` change
- Repo: https://github.com/dodopayments/dualmark
- Live demo + playground: https://dualmark.dev/play

Happy to adjust placement or wording.