### PR TITLE
Add Helium to Built with Astro

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,4 +191,5 @@ Pre 1.0
 - [Matrix Digital Rain Online with Terminal](https://matrixscreensaver.online/)
 - [Tally](https://tally.johng.io) ([Source](https://github.com/twocaretcat/Tally))
 - [Goldplated Photos](https://goldplated.photos) - Self-hosted photo gallery with file-based storage, password protection, and PhotoSwipe lightbox ([Source](https://github.com/klukacin/goldplated-photos))
+- [Helium](https://www.heliumedu.com) ([Source](https://github.com/HeliumEdu/www))
 


### PR DESCRIPTION
www.heliumedu.com is the marketing + support portal for Helium, an open-source student planner with iOS, Android, and web apps. Built on Astro + Tailwind (AstroWind starter), using Astro content collections for the in-repo knowledge base.

Source: https://github.com/HeliumEdu/www