### PR TITLE
Add astro-sparkline to Astro Packages/Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Pre 1.0
 - [Astro Gist](https://github.com/kotosha-real/astro-gist) - Astro component to easily add GitHub gists to your blog
 - [Astro Breadcrumbs](https://github.com/felix-berlin/astro-breadcrumbs) - Well configurable breadcrumb component for Astro. Create breadcrumbs completely dynamically or specify exactly how they should look.
 - [astro-loader-goodreads](https://github.com/sadmanca/astro-loader-goodreads) - Load Goodreads data for books in shelves/lists, user updates, and author blogs into Astro.
+- [astro-sparkline](https://www.npmjs.com/package/astro-sparkline) - Tiny inline-SVG sparkline component for Astro. Zero runtime, zero dependencies, server-rendered. ~90 lines.
 
 ## Astro Integrations
 - [Astro Content](https://github.com/JulianCataldo/astro-content) - A text based, structured content manager, for edition and consumption — AstroJS Integration


### PR DESCRIPTION
Adding a small zero-dependency Astro component to the **Astro Packages/Libraries** section.

**Package**: [astro-sparkline](https://www.npmjs.com/package/astro-sparkline)
**Source**: [github.com/MarvinBregiosa/astro-sparkline](https://github.com/MarvinBregiosa/astro-sparkline)
**License**: MIT

A tiny inline-SVG sparkline component. Zero runtime, zero dependencies, server-rendered — ~90 lines. Drops into any Astro page or component and produces a plain `<svg>` with a polyline and an optional end-of-series dot at build time. No client-side JS.

```astro
---
import Sparkline from 'astro-sparkline';
const series = [4, 6, 1, 4, 7, 3, 3];
---
<Sparkline data={series} width={80} height={20} />
```

Live production example in a 19-city data table: [Vision Zero Report Card 2026](https://accidentlawyerreview.com/research/vision-zero-report-card/) (the "Trend" column).

Inserted at the end of the existing Packages/Libraries section to keep the same format and topical cluster.