### PR TITLE
Add Prismix to Built with Astro

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,4 +191,5 @@ Pre 1.0
 - [Matrix Digital Rain Online with Terminal](https://matrixscreensaver.online/)
 - [Tally](https://tally.johng.io) ([Source](https://github.com/twocaretcat/Tally))
 - [Goldplated Photos](https://goldplated.photos) - Self-hosted photo gallery with file-based storage, password protection, and PhotoSwipe lightbox ([Source](https://github.com/klukacin/goldplated-photos))
+- [Prismix](https://prismix.dev) - AI hub combining real-time status monitoring of 75+ AI services, curated news from 70+ sources, and a directory of 500+ MCP servers. Built on Astro 5 SSR + Cloudflare Workers.
 


### PR DESCRIPTION
Adds [Prismix](https://prismix.dev) to the **Built with Astro** section.

Prismix is an AI hub built entirely on Astro 5 SSR + Cloudflare Workers + KV (free tier):

- **Status:** real-time monitoring of 75+ AI services (OpenAI, Anthropic, Cursor, etc.)
- **News:** curated AI news from 70+ RSS sources (Anthropic, OpenAI, HN AI tag, arXiv ML, TechCrunch)
- **MCP:** directory of 500+ Model Context Protocol servers with bundles + release tracking

Astro-specific patterns used:
- Server-rendered pages with Preact islands for likes/follows (zero CSR for most users)
- `tap` prefetch strategy + pointerdown progress bar for instant-feel navigation
- Per-route `prerender: false` on dynamic pages, `prerender: true` on `/what-is-mcp` / `/about`

Stack writeup: https://dev.to/max_98b3db49c06de66802dcd/4-perf-walls-i-hit-shipping-an-ai-hub-on-cloudflare-workers-kv-246

Happy to adjust the entry format if anything doesn't match repo conventions.