### PR TITLE
Add @unirate/astro to Astro Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Pre 1.0
 - [ParaglideJS](https://inlang.com/m/iljlwzfs/library-inlang-paraglideJsAdapterAstro) - A tiny, type-safe i18n integration that only ships messages used on islands to the client.
 - [astro-cloudflare-pages-headers](https://github.com/martinsilha/astro-cloudflare-pages-headers) - A lightweight integration for Astro that automatically generates a Cloudflare Pages `_headers` file for deployments based on your server header configuration.
 - [@aeorank/astro](https://github.com/vinpatel/aeorank) - AEO (Answer Engine Optimization) integration for Astro — generates llms.txt, schema.json, and more AI-readable files
+- [@unirate/astro](https://github.com/UniRate-API/astro-unirate) - Astro integration for currency conversion with `<Currency />` and `<Rate />` components, powered by the UniRate API.
 
 ## Built with Astro
 - https://astro.build/showcase/ (__Official Showcase Directory__)


### PR DESCRIPTION
Adds [@unirate/astro](https://github.com/UniRate-API/astro-unirate) to the **Astro Integrations** section.

`@unirate/astro` is a proper Astro integration that fetches a currency rate snapshot at build time via `astro:config:setup`, registers a Vite virtual module (`virtual:unirate`), and injects type declarations via `astro:config:done`. Ships `<Currency />` and `<Rate />` components plus `convertCurrency`/`getRate`/`formatCurrency` helpers. Zero runtime deps, published on [npm](https://www.npmjs.com/package/@unirate/astro) with provenance attestation. 33 vitest mock tests, CI matrix Node 20/22.

**Disclosure:** I maintain the UniRate API and this integration.