### PR TITLE
Add Prismix to Built with Astro showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Pre 1.0
 - [jmae.xyz](https://jmae.xyz/work/)
 - [meteor10](https://meteor10.sachagreif.com/)
 - [Astro Hackathon Showcase](https://hackathon-1-0-projects.vercel.app/)
+- [Prismix](https://prismix.dev) — AI hub built with Astro 5 SSR + Cloudflare Workers + KV + Preact islands: live status for 75+ AI services, curated news from 70+ sources, and a 600+ MCP server directory.
 - [andri.dk/](https://andri.dk/)
 - [alchemycodelab.com](https://www.alchemycodelab.com/)
 - [petar.radojevic.rs](https://petar.radojevic.rs/en)


### PR DESCRIPTION
## What this adds

Adds [Prismix](https://prismix.dev) to the "Built with Astro" section.

Prismix is an AI hub built with **Astro 5 SSR + Cloudflare Workers + KV + Preact islands**:
- **Status monitoring** — live status for 75+ AI services (OpenAI, Anthropic, Cursor, etc.), email/webhook alerts, embeddable SVG badges
- **News aggregation** — curated AI news from 70+ RSS sources, personalized feed
- **MCP directory** — 600+ MCP servers with bundles, install commands, release tracking

Runs on **/usr/bin/bash/mo** on Cloudflare free tier. Free public status API.

Live: https://prismix.dev