### PR TITLE
Add Bitcoin Institute under Built with Astro

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,4 +191,5 @@ Pre 1.0
 - [Matrix Digital Rain Online with Terminal](https://matrixscreensaver.online/)
 - [Tally](https://tally.johng.io) ([Source](https://github.com/twocaretcat/Tally))
 - [Goldplated Photos](https://goldplated.photos) - Self-hosted photo gallery with file-based storage, password protection, and PhotoSwipe lightbox ([Source](https://github.com/klukacin/goldplated-photos))
+- [Bitcoin Institute](https://bitcoin-institute.pages.dev) - Bilingual (EN/JP) Satoshi Nakamoto primary-source archive with d3 and Mermaid visualizations
 


### PR DESCRIPTION
Adds **Bitcoin Institute** under *Built with Astro*.

A bilingual (English/Japanese) reference archive of Satoshi Nakamoto's primary sources, built with Astro. It uses d3 and Mermaid for the stylometric / timeline visualizations, content collections for the EN/JP entries, and ships fully static.

- Live: https://bitcoin-institute.pages.dev
- Matches the section format `- [NAME](LINK) - description`
- Not a duplicate.
