### PR TITLE
Add CloudCertPrep to Built with Astro

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,4 +191,5 @@ Pre 1.0
 - [Matrix Digital Rain Online with Terminal](https://matrixscreensaver.online/)
 - [Tally](https://tally.johng.io) ([Source](https://github.com/twocaretcat/Tally))
 - [Goldplated Photos](https://goldplated.photos) - Self-hosted photo gallery with file-based storage, password protection, and PhotoSwipe lightbox ([Source](https://github.com/klukacin/goldplated-photos))
+- [CloudCertPrep](https://www.cloudcertprep.io) - Free and open-source AWS practice exams with questions explanations. No signup, no ads, every answer auditable on GitHub ([Source](https://github.com/nastaso/cloudcertprep))
 


### PR DESCRIPTION
CloudCertPrep (https://www.cloudcertprep.io) is a free, open-source AWS certification practice exam site built with Astro (prerendered static pages with React islands). Source: https://github.com/nastaso/cloudcertprep