### PR TITLE
Add astroblog to Repositories/Starter Kits/Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Pre 1.0
 - [Astro Citrus](https://github.com/ArtemKutsan/astro-citrus) - A modern Astro blog theme with MDX and Tailwind CSS
 - [Starwind UI](https://github.com/starwind-ui/starwind-ui) - A set of powerful, accessible components for your Astro projects. Styled with Tailwind CSS v4.
 - [WebcoreUI](https://webcoreui.dev/) - Configurable and themeable Astro component UI library
+- [astroblog](https://github.com/alex-on-ai/astroblog) - Fast statically generated Astro blog starter with Tailwind, Giscus comments and Pages CMS
 
 ## Astro Packages/Libraries
 - [Astro SEO](https://github.com/jonasmerlin/astro-seo) - Better SEO with Astro


### PR DESCRIPTION
Adds astroblog, a fast statically generated Astro blog starter.

- Astro content collections (markdown + zod), near-zero client JS
- Tailwind CSS, Giscus comments, Prism code highlighting
- Git-as-CMS through Pages CMS, deployed on Vercel
- Marked as a GitHub template repository so Use this template works

Repo: https://github.com/alex-on-ai/astroblog
Live demo: https://alexpavlov.dev