### PR TITLE
Add Room TBA

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,4 +191,5 @@ Pre 1.0
 - [Matrix Digital Rain Online with Terminal](https://matrixscreensaver.online/)
 - [Tally](https://tally.johng.io) ([Source](https://github.com/twocaretcat/Tally))
 - [Goldplated Photos](https://goldplated.photos) - Self-hosted photo gallery with file-based storage, password protection, and PhotoSwipe lightbox ([Source](https://github.com/klukacin/goldplated-photos))
+- [Room TBA](https://room-tba.uplbtools.me) - UPLB campus map app with Svelte islands, Drizzle ORM, and offline PGlite sync ([Source](https://github.com/uplbtools/room-tba))
 


### PR DESCRIPTION
## Summary
Adds [Room TBA](https://room-tba.uplbtools.me) to **Built with Astro**: a production UPLB campus map PWA (Astro 7 + Svelte 5 islands, Drizzle, offline PGlite sync).

- Live: https://room-tba.uplbtools.me
- Source: https://github.com/uplbtools/room-tba
- License: MIT

## Test plan
- [x] Entry matches existing Built with Astro format with Source link