### PR TITLE
Add UPLB / uplbtools Astro sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,4 +193,8 @@ Pre 1.0
 - [Tally](https://tally.johng.io) ([Source](https://github.com/twocaretcat/Tally))
 - [Goldplated Photos](https://goldplated.photos) - Self-hosted photo gallery with file-based storage, password protection, and PhotoSwipe lightbox ([Source](https://github.com/klukacin/goldplated-photos))
 - [Watchboard](https://artemiop.com/watchboard/) - AI-powered intelligence dashboard platform with 48 trackers, CesiumJS 3D globe, Leaflet maps, and nightly automated data updates ([Source](https://github.com/ArtemioPadilla/watchboard))
+- [Freshie Guide](https://guide.stimmie.dev/) ([Source](https://github.com/smmariquit/freshie-guide)) - Open-source handbooks for incoming UPLB freshmen.
+- [joinpizza.fun](https://www.joinpizza.fun/) ([Source](https://github.com/smmariquit/joinpizza.fun)) - Site for Pizza & Friends, a Filipino tech community.
+- [Room TBA](https://room-tba.uplbtools.me/) ([Source](https://github.com/uplbtools/room-tba)) - UPLB campus room finder with Svelte islands, offline PWA, and OpenStreetMap directions.
+- [uplbtools.me](https://www.uplbtools.me/) ([Source](https://github.com/uplbtools/uplbtools.me)) - Hub listing open-source utilities for UPLB students.
 


### PR DESCRIPTION
Adds open-source UPLB / uplbtools projects (public repos only).

## Projects
- Room TBA, Freshie Guide, uplbtools.me, joinpizza.fun (as applicable per list)
- GradeSim (chrome list)
- web.stimmie.dev (portfolio lists)

Maintainer: @smmariquit / uplbtools org.