### PR TITLE
Add RoundCut to Built with Astro

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Pre 1.0
 - [Serverless(CSS Tricks)](https://serverless.css-tricks.com/)
 - [Trivago - Tech Blog](https://tech.trivago.com/)
 - [Taiwan.md](https://taiwan.md) - Open-source, AI-friendly knowledge base about Taiwan. 400+ Markdown articles, bilingual, knowledge graph, and public API. ([GitHub](https://github.com/frank890417/taiwan-md) — 600+ ⭐)
+- [RoundCut](https://roundcut.app/) - Free client-side image tools (circle crop, compress, convert, background removal) in 29 languages — Astro 6 SSG with WASM codecs running in the browser.
 - [Rokt](https://www.rokt.com/)
 - [Backlight](https://backlight.dev/)
 - [Apparently.cz](https://apparently.cz)


### PR DESCRIPTION
Adding [RoundCut](https://roundcut.app/) to the **Built with Astro** section.

Disclosure: I'm the developer of RoundCut.

RoundCut is a free set of browser-based image tools (circle crop, compress, convert, background removal) available in 29 languages. Built with Astro 6 (fully static SSG), deployed on Cloudflare Workers, with WASM image codecs (jSquash) running entirely client-side. Entry follows the existing format (name + short description, as in the Taiwan.md entry).