### PR TITLE
Add Astro Keel (portfolio + blog theme)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Pre 1.0
 - [Astro Citrus](https://github.com/ArtemKutsan/astro-citrus) - A modern Astro blog theme with MDX and Tailwind CSS
 - [Starwind UI](https://github.com/starwind-ui/starwind-ui) - A set of powerful, accessible components for your Astro projects. Styled with Tailwind CSS v4.
 - [WebcoreUI](https://webcoreui.dev/) - Configurable and themeable Astro component UI library
+- [Astro Keel](https://github.com/kpab/astro-keel) - A minimal, neutral portfolio + blog theme with a one-line accent color, dark mode, tags, table of contents, and RSS
 
 ## Astro Packages/Libraries
 - [Astro SEO](https://github.com/jonasmerlin/astro-seo) - Better SEO with Astro


### PR DESCRIPTION
Adds [Astro Keel](https://github.com/kpab/astro-keel) to the Repositories/Starter Kits/Components section.

Astro Keel is a minimal, neutral portfolio + blog theme for Astro 7 (MIT licensed):

- One-line accent color — the whole theme retunes from a single CSS variable
- Light/dark mode with no flash on load
- Content Collections (works + blog), tags, per-post table of contents, RSS
- Shiki dual-theme syntax highlighting, self-hosted fonts, sitemap/OG out of the box
- Live demo: https://kpab.github.io/astro-keel/ (also listed in the official Astro themes catalog)

Thanks for the great list!