### PR TITLE
Add AstroCanvas to Astro integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Pre 1.0
 - [Google Font Optimizer](https://github.com/sebholstein/astro-google-fonts-optimizer) - An Astro integration to optimize the Google Fonts loading performance
 - [Astro Firebase](https://github.com/thepassle/astro-firebase) - Deploy your server-side rendered (SSR) Astro app to Firebase
 - [Astro Font Picker](https://github.com/randombits-dev/astro-font-picker) - A Dev Toolbar Integration that lets you try out different fonts on your website
+- [AstroCanvas](https://astrocanvas.site/) - A local visual editor and Dev Toolbar integration that saves safe, marked text edits back to real `.astro` source files.
 - [Astro Snapshot](https://github.com/twocaretcat/astro-snapshot) - An Astro integration for generating screenshots of your pages automatically at build time
 - [ParaglideJS](https://inlang.com/m/iljlwzfs/library-inlang-paraglideJsAdapterAstro) - A tiny, type-safe i18n integration that only ships messages used on islands to the client.
 - [astro-cloudflare-pages-headers](https://github.com/martinsilha/astro-cloudflare-pages-headers) - A lightweight integration for Astro that automatically generates a Cloudflare Pages `_headers` file for deployments based on your server header configuration.
@@ -193,4 +194,3 @@ Pre 1.0
 - [Tally](https://tally.johng.io) ([Source](https://github.com/twocaretcat/Tally))
 - [Goldplated Photos](https://goldplated.photos) - Self-hosted photo gallery with file-based storage, password protection, and PhotoSwipe lightbox ([Source](https://github.com/klukacin/goldplated-photos))
 - [Watchboard](https://artemiop.com/watchboard/) - AI-powered intelligence dashboard platform with 48 trackers, CesiumJS 3D globe, Leaflet maps, and nightly automated data updates ([Source](https://github.com/ArtemioPadilla/watchboard))
-


### PR DESCRIPTION
## What

Adds AstroCanvas to the Astro Integrations section.

## Why

AstroCanvas is an Astro Dev Toolbar integration for visually editing explicitly marked text during local development and saving safe changes back to the original `.astro` source file.

## Validation

- Confirmed the production site is live at https://astrocanvas.site/
- Kept the change to one alphabetical-neighbouring list entry
- Verified the README diff has no whitespace errors
