### PR TITLE
Add Araluma to Built with Astro

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,4 +193,5 @@ Pre 1.0
 - [Tally](https://tally.johng.io) ([Source](https://github.com/twocaretcat/Tally))
 - [Goldplated Photos](https://goldplated.photos) - Self-hosted photo gallery with file-based storage, password protection, and PhotoSwipe lightbox ([Source](https://github.com/klukacin/goldplated-photos))
 - [Watchboard](https://artemiop.com/watchboard/) - AI-powered intelligence dashboard platform with 48 trackers, CesiumJS 3D globe, Leaflet maps, and nightly automated data updates ([Source](https://github.com/ArtemioPadilla/watchboard))
+- [Araluma](https://araluma.com/) - Free online image tools that run in your browser: compress, convert, resize, crop, and background removal. No account needed.
 


### PR DESCRIPTION
Adding [Araluma](https://araluma.com/) to the **Built with Astro** section.

Disclosure: I'm the maker of Araluma.

Araluma is a free set of online image tools that run entirely in the browser — compress, convert, resize, crop, and background removal — with no account or upload required for most tools. It's built with Astro (fully static SSG) and deployed on Cloudflare.

Entry follows the format of the neighboring items and is appended at the end of the section. Happy to adjust wording or placement if you prefer.