### PR TITLE
Add Clerk to Astro Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Pre 1.0
 - [Astro Snapshot](https://github.com/twocaretcat/astro-snapshot) - An Astro integration for generating screenshots of your pages automatically at build time
 - [ParaglideJS](https://inlang.com/m/iljlwzfs/library-inlang-paraglideJsAdapterAstro) - A tiny, type-safe i18n integration that only ships messages used on islands to the client.
 - [astro-cloudflare-pages-headers](https://github.com/martinsilha/astro-cloudflare-pages-headers) - A lightweight integration for Astro that automatically generates a Cloudflare Pages `_headers` file for deployments based on your server header configuration.
+- [Clerk](https://clerk.com/docs/quickstarts/astro) - Official Clerk integration for auth and user management, with Astro components and middleware
 
 ## Built with Astro
 - https://astro.build/showcase/ (__Official Showcase Directory__)


### PR DESCRIPTION
Adds Clerk's official Astro integration — auth and user management with Astro components and middleware for both static and SSR. Quickstart: https://clerk.com/docs/quickstarts/astro