### PR TITLE
Add SaaS Landing Kit (free Astro + Tailwind template)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Pre 1.0
 - [Gurido](https://gurido.vercel.app/) A super cool, playfull and modern landing page template for agencies, studios or freelancers built with Astro and Tailwind CSS.
 - [MicroBlog](https://microblog-theta.vercel.app/) - An elegant blog website template built with Astro, Tailwind CSS and MDX.
 - [Quick Store](https://quickstorre.vercel.app/) - A minimal dark theme landing page to sell digital products.
+- [SaaS Landing Kit](https://haierr1.github.io/) ([source](https://github.com/haierr1/saas-landing-kit)) - Free SaaS landing page template with dark mode, one-file theming and accessible components, built with Astro and Tailwind CSS.
 - [Astro Citrus](https://github.com/ArtemKutsan/astro-citrus) - A modern Astro blog theme with MDX and Tailwind CSS
 - [Starwind UI](https://github.com/starwind-ui/starwind-ui) - A set of powerful, accessible components for your Astro projects. Styled with Tailwind CSS v4.
 - [WebcoreUI](https://webcoreui.dev/) - Configurable and themeable Astro component UI library


### PR DESCRIPTION
Adds [SaaS Landing Kit](https://github.com/haierr1/saas-landing-kit) to the templates section — a free, open-source SaaS landing page template built with Astro + Tailwind CSS: dark/light mode with no-flash init, one-file theming via CSS variables, accessible (skip link, landmarks, focus states, reduced motion), static output with no runtime CDNs. Live demo: https://haierr1.github.io/

Placed after Quick Store to match the surrounding template entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)