### PR TITLE
Add notabene to Astro Packages/Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Pre 1.0
 - [Astro Gist](https://github.com/kotosha-real/astro-gist) - Astro component to easily add GitHub gists to your blog
 - [Astro Breadcrumbs](https://github.com/felix-berlin/astro-breadcrumbs) - Well configurable breadcrumb component for Astro. Create breadcrumbs completely dynamically or specify exactly how they should look.
 - [astro-loader-goodreads](https://github.com/sadmanca/astro-loader-goodreads) - Load Goodreads data for books in shelves/lists, user updates, and author blogs into Astro.
+- [notabene](https://github.com/z29k/notabene) - Renders a repo's Markdown/MDX as a navigable docs site with anchored, Google-Docs-style comments that an AI agent applies back to the source files.
 
 ## Astro Integrations
 - [Astro Content](https://github.com/JulianCataldo/astro-content) - A text based, structured content manager, for edition and consumption — AstroJS Integration


### PR DESCRIPTION
Adds [notabene](https://github.com/z29k/notabene) to the *Astro Packages/Libraries* section.

notabene is an Astro-based renderer that turns a repo's Markdown/MDX into a navigable docs site where you can leave anchored, Google-Docs-style comments. The comments are stored as JSON in the repo itself, so an AI agent can read them and apply the feedback back to the source files.

On the Astro side it is a generic, run-from-package renderer: it lives in the consumer's `node_modules` and is pointed at any repo at runtime, sourcing content from outside the Astro app via content collections. Ships with i18n, Pagefind search, PDF export and a static public build mode.

MIT, published as [`@z29k/notabene`](https://www.npmjs.com/package/@z29k/notabene), docs at https://z29k.github.io/notabene/

Entry follows the existing `- [Name](link) - Description` format and is appended at the end of the section.