### PR TITLE
Add arthurs.tw to Built with Astro

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,3 +202,4 @@ Pre 1.0
 - [PolyGlyph](https://polyglyph.io/) - AI-powered SVG generation and editing tool built with Astro and Svelte 5
 - [Watchboard](https://artemiop.com/watchboard/) - AI-powered intelligence dashboard platform with 48 trackers, CesiumJS 3D globe, Leaflet maps, and nightly automated data updates ([Source](https://github.com/ArtemioPadilla/watchboard))
 
+- [arthurs.tw](https://arthurs.tw) - Traditional Chinese consultancy site, content-collection driven with design and copy linters in CI, sitemap with per-page lastmod, and JSON-LD on every route ([Source](https://github.com/yao-care/arthurs.tw))


### PR DESCRIPTION
Adds one entry to the **Built with Astro** section.

[arthurs.tw](https://arthurs.tw) is a Traditional Chinese consultancy site built with Astro 6 and `@astrojs/sitemap`, source public at [yao-care/arthurs.tw](https://github.com/yao-care/arthurs.tw).

A few things in it that may be of interest to other Astro users:

- All content lives in content collections (`src/content`), so the site can be updated by editing Markdown alone.
- Two custom lint scripts run before every build and fail it on violation: one enforces the design system (no hard-coded colours, no px font sizes, no external CDNs), the other catches formulaic copy patterns.
- The sitemap `serialize` hook writes a real per-page `lastmod`, sourced from content frontmatter for collection pages and from the file's last git commit date for static pages.
- JSON-LD (Organization, WebSite, Service, FAQPage, BreadcrumbList, Article) is emitted per route from a single module.

Entry follows the existing format with a short description and a Source link.