### PR TITLE
Add astro-swiper to Astro Packages/Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Pre 1.0
 - [Astro Gist](https://github.com/kotosha-real/astro-gist) - Astro component to easily add GitHub gists to your blog
 - [Astro Breadcrumbs](https://github.com/felix-berlin/astro-breadcrumbs) - Well configurable breadcrumb component for Astro. Create breadcrumbs completely dynamically or specify exactly how they should look.
 - [astro-loader-goodreads](https://github.com/sadmanca/astro-loader-goodreads) - Load Goodreads data for books in shelves/lists, user updates, and author blogs into Astro.
+- [Astro Swiper](https://pascal-brand38.github.io/astro-dev/packages/astro-swiper/) - Astro component for Swiper, designed to easily create carousels. Navigation (swiping on mobile, or using navigation arrows), pagination, thumbnails, transition effects... can be added.
 
 ## Astro Integrations
 - [Astro Content](https://github.com/JulianCataldo/astro-content) - A text based, structured content manager, for edition and consumption — AstroJS Integration


### PR DESCRIPTION
Adding astro-swiper to the Repositories/Starter Kits section.

This is an Astro component for Swiper, designed to easily create carousels with thumbnails.

* Demo and doc: https://pascal-brand38.github.io/astro-dev/packages/astro-swiper/
* github: https://github.com/pascal-brand38/astro-swiper
* MIT licensed