### PR TITLE
Add @i18n-micro/astro

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Pre 1.0
 - [ParaglideJS](https://inlang.com/m/iljlwzfs/library-inlang-paraglideJsAdapterAstro) - A tiny, type-safe i18n integration that only ships messages used on islands to the client.
 - [astro-cloudflare-pages-headers](https://github.com/martinsilha/astro-cloudflare-pages-headers) - A lightweight integration for Astro that automatically generates a Cloudflare Pages `_headers` file for deployments based on your server header configuration.
 - [@aeorank/astro](https://github.com/vinpatel/aeorank) - AEO (Answer Engine Optimization) integration for Astro — generates llms.txt, schema.json, and more AI-readable files
+- [@i18n-micro/astro](https://github.com/s00d/nuxt-i18n-micro/tree/main/packages/astro) - Lightweight Astro integration for i18n-micro (translations, routing, and islands)
 
 ## Built with Astro
 - https://astro.build/showcase/ (__Official Showcase Directory__)


### PR DESCRIPTION
## Summary
- Add [`@i18n-micro/astro`](https://github.com/s00d/nuxt-i18n-micro/tree/main/packages/astro) to **Astro Integrations**
- Lightweight Astro integration for [i18n-micro](https://github.com/s00d/nuxt-i18n-micro) (translations, routing, islands)


Made with [Cursor](https://cursor.com)